### PR TITLE
🧹 Adds `projects.scripts`. Fixes deprecated `license` table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ class Athletes(SQLModel, table = True):
 CLI usage is supported, for example one can invokem with:
 
 ```bash
-python3 -m sqlmodelgen -f /my/path/to/file.sql -o /my/path/to/output.py
+sqlmodelgen -f /my/path/to/file.sql -o /my/path/to/output.py
 ```
 
 help description for input arguments:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 ]
 version = "0.0.20"
 description = "Generate SQLModel code from SQL"
-license = {file = "LICENSE"}
+license-files = ['LICENSE']
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
@@ -24,6 +24,9 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14"
 ]
+
+[project.scripts]
+sqlmodelgen = "sqlmodelgen.cli:main_cli"
 
 [project.urls]
 Repository = "https://github.com/nucccc/sqlmodelgen"

--- a/uv.lock
+++ b/uv.lock
@@ -601,7 +601,7 @@ wheels = [
 
 [[package]]
 name = "sqlmodelgen"
-version = "0.0.18"
+version = "0.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "sqloxide" },


### PR DESCRIPTION
This patch tweaks the pyproject.toml in a couple of three ways.

1. The `license` table has been depracated per [pep-0639](https://peps.python.org/pep-0639/#deprecate-license-key-table-subkeys) Apparently now it's `license-files` or a license-expression. UV build shows that the license file still shows up on the tar, so it should all be good.
2. Adds `projects.scripts`. `sqlmodel` should now be invokable directly from the cli after installation.
~3. Bumps up the version.~ Keeps the version number as is.

should close #21